### PR TITLE
Add missing 'test-unit' development dependency

### DIFF
--- a/duo_web.gemspec
+++ b/duo_web.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   ]
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'rubocop', '~> 0'
+  s.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
The [test-unit](https://github.com/test-unit/test-unit) gem is a required dependency (required in `test/test_duo_web.rb`).